### PR TITLE
Add possibility to add extendedKeyUsage to user certificate

### DIFF
--- a/univention-usercert/debian/univention-usercert.univention-config-registry-variables
+++ b/univention-usercert/debian/univention-usercert.univention-config-registry-variables
@@ -70,7 +70,7 @@ Description[en]=Certificate locality value to ldap attribut mapping
 Type=str
 Categories=SSL
 
-[ssl/usercert/extendedkeyusage]
+[ssl/usercert/extended-key-usage]
 Description[de]=Wert für extendedKeyUsage, der den Benutzerzertifikaten hinzugefügt wird
 Description[en]=Value for extendedKeyUsage to be added to the user certificates
 Type=str

--- a/univention-usercert/debian/univention-usercert.univention-config-registry-variables
+++ b/univention-usercert/debian/univention-usercert.univention-config-registry-variables
@@ -70,6 +70,12 @@ Description[en]=Certificate locality value to ldap attribut mapping
 Type=str
 Categories=SSL
 
+[ssl/usercert/extendedkeyusage]
+Description[de]=Wert für extendedKeyUsage, der den Benutzerzertifikaten hinzugefügt wird
+Description[en]=Value for extendedKeyUsage to be added to the user certificates
+Type=str
+Categories=SSL
+
 [ssl/usercert/extensionsfile]
 Description[de]=Datei mit Zertifikats-Erweiertungen für Benutzer-Zertifikate (openssl -> -extfile)
 Description[en]=File with extensions for user certificates (openssl -> -extfile)

--- a/univention-usercert/make-certificates-user.sh
+++ b/univention-usercert/make-certificates-user.sh
@@ -35,6 +35,7 @@
 # http://www.pca.dfn.de/dfnpca/certify/ssl/handbuch/ossl092/
 
 DEFAULT_DAYS=$(/usr/sbin/univention-config-registry get ssl/usercert/days)
+EXTENDED_KEY_USAGE=$(/usr/sbin/univention-config-registry get ssl/usercert/extendedkeyusage)
 . /usr/share/univention-ssl/make-certificates.sh
 [ -n "$ca" ] && CA="${ca}"
 
@@ -167,6 +168,7 @@ authorityKeyIdentifier  = keyid,issuer:always
 basicConstraints = critical, CA:FALSE
 keyUsage = nonRepudiation, digitalSignature, keyEncipherment
 ${SAN_txt:+subjectAltName = $SAN_txt}
+${EXTENDED_KEY_USAGE:+extendedKeyUsage = $EXTENDED_KEY_USAGE}
 
 [ v3_ca ]
 

--- a/univention-usercert/make-certificates-user.sh
+++ b/univention-usercert/make-certificates-user.sh
@@ -35,7 +35,7 @@
 # http://www.pca.dfn.de/dfnpca/certify/ssl/handbuch/ossl092/
 
 DEFAULT_DAYS=$(/usr/sbin/univention-config-registry get ssl/usercert/days)
-EXTENDED_KEY_USAGE=$(/usr/sbin/univention-config-registry get ssl/usercert/extendedkeyusage)
+EXTENDED_KEY_USAGE=$(/usr/sbin/univention-config-registry get ssl/usercert/extended-key-usage)
 . /usr/share/univention-ssl/make-certificates.sh
 [ -n "$ca" ] && CA="${ca}"
 


### PR DESCRIPTION
I added a new feature to configure the `extendedKeyUsage` for a user certificate in a UCR variable. This is e.g. useful, if you want to use the user certificates for authentication for a VPN.

If you have any requirements or ideas for improvement, that it can get merged, just let me know and i will try to implement this.

Thanks for your great work :)